### PR TITLE
Force git cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ In non-interactive mode, it will will print these files for your inspection.
 In interactive mode (with `-i`), `reddup` will interactively help you "reddup"
 the repository.
 
+In force mode (when the repository has a `force: true` flag), it will
+automatically create a WIP commit and push branches to remote. The force flag
+is optional, and false by default.
+
 Options include:
 
 - Committing all changes (deleted, staged, unstaged, untracked).
@@ -82,6 +86,7 @@ Here is the one I am using right now:
 locations:
   - type: git
     location: ~/EF
+    force: true
   - type: git
     location: ~/Reference
   - type: git

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -5,7 +5,6 @@ module Config where
 import Data.Maybe (fromMaybe)
 import qualified Data.Yaml as Y
 import Data.Yaml (FromJSON(..), (.:), (.:?))
--- import Control.Applicative
 import Data.Text hiding (empty)
 import qualified Turtle as Tu
 import Data.ByteString as BS
@@ -34,8 +33,17 @@ data Config =
     } deriving (Eq, Show)
 
 data LocationSpec
-  = GitLoc {location :: Text}
-  | InboxLoc {location :: Text, ignoredFiles :: [Text] }
+  = GitLoc GitLocation
+  | InboxLoc InboxLocation
+  deriving (Eq, Show)
+
+data GitLocation = GitLocation { gitLocation :: Text }
+  deriving (Eq, Show)
+
+data InboxLocation = InboxLocation
+    { inboxLocation :: Text
+    , ignoredFiles :: [Text]
+    }
   deriving (Eq, Show)
 
 data HandlerSpecs =
@@ -76,8 +84,8 @@ instance FromJSON LocationSpec where
     location' <- v .:  "location"
     ignoredFiles' <- v .:? "ignored_files"
     case (T.unpack $ type') of
-      "git" -> return $ GitLoc location'
-      "inbox" -> return $ InboxLoc location' (fromMaybe [] ignoredFiles')
+      "git" -> return $ GitLoc $ GitLocation location'
+      "inbox" -> return $ InboxLoc $ InboxLocation location' (fromMaybe [] ignoredFiles')
       _ -> fail $ "Location type must be either 'git' or 'inbox', found '" <> T.unpack type' <> "'"
 
 instance FromJSON HandlerSpecs where

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -2,6 +2,7 @@
 
 module Config where
 
+import Data.Maybe (fromMaybe)
 import qualified Data.Yaml as Y
 import Data.Yaml (FromJSON(..), (.:), (.:?))
 -- import Control.Applicative
@@ -34,7 +35,7 @@ data Config =
 
 data LocationSpec
   = GitLoc {location :: Text}
-  | InboxLoc {location :: Text, ignoredFiles :: Maybe [Text] }
+  | InboxLoc {location :: Text, ignoredFiles :: [Text] }
   deriving (Eq, Show)
 
 data HandlerSpecs =
@@ -76,7 +77,7 @@ instance FromJSON LocationSpec where
     ignoredFiles' <- v .:? "ignored_files"
     case (T.unpack $ type') of
       "git" -> return $ GitLoc location'
-      "inbox" -> return $ InboxLoc location' ignoredFiles'
+      "inbox" -> return $ InboxLoc location' (fromMaybe [] ignoredFiles')
       _ -> fail $ "Location type must be either 'git' or 'inbox', found '" <> T.unpack type' <> "'"
 
 instance FromJSON HandlerSpecs where

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -37,7 +37,10 @@ data LocationSpec
   | InboxLoc InboxLocation
   deriving (Eq, Show)
 
-data GitLocation = GitLocation { gitLocation :: Text }
+data GitLocation = GitLocation
+    { gitLocation :: Text
+    , gitForce    :: Bool
+    }
   deriving (Eq, Show)
 
 data InboxLocation = InboxLocation
@@ -82,9 +85,10 @@ instance FromJSON LocationSpec where
   parseJSON = Y.withObject "LocationSpec" $ \v -> do
     type'     <- v .:  "type"
     location' <- v .:  "location"
+    force     <- v .:? "force"
     ignoredFiles' <- v .:? "ignored_files"
     case (T.unpack $ type') of
-      "git" -> return $ GitLoc $ GitLocation location'
+      "git" -> return $ GitLoc $ GitLocation location' (fromMaybe False force)
       "inbox" -> return $ InboxLoc $ InboxLocation location' (fromMaybe [] ignoredFiles')
       _ -> fail $ "Location type must be either 'git' or 'inbox', found '" <> T.unpack type' <> "'"
 

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -126,8 +126,8 @@ isFileIgnored file locSpec =
 ignoredFiles :: C.LocationSpec -> [Tu.FilePath]
 ignoredFiles locSpec =
   case locSpec of
-    C.GitLoc _loc -> []
-    C.InboxLoc _loc ignoredFiles' ->
+    C.GitLoc _ -> []
+    C.InboxLoc (C.InboxLocation _ ignoredFiles') ->
       Tu.fromString . T.unpack <$> ignoredFiles'
 
 printMenuCustomCommands :: [C.InboxHandlerCommandSpec] -> IO ()

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -128,7 +128,7 @@ ignoredFiles locSpec =
   case locSpec of
     C.GitLoc _loc -> []
     C.InboxLoc _loc ignoredFiles' ->
-      maybe [] ((Tu.fromString . T.unpack) <$>) ignoredFiles'
+      Tu.fromString . T.unpack <$> ignoredFiles'
 
 printMenuCustomCommands :: [C.InboxHandlerCommandSpec] -> IO ()
 printMenuCustomCommands ihcSpecs = do

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -130,6 +130,13 @@ ignoredFiles locSpec =
     C.InboxLoc (C.InboxLocation _ ignoredFiles') ->
       Tu.fromString . T.unpack <$> ignoredFiles'
 
+force :: C.LocationSpec -> Bool
+force locSpec =
+  case locSpec of
+    C.GitLoc (C.GitLocation _ f) -> f
+    _ -> False
+
+
 printMenuCustomCommands :: [C.InboxHandlerCommandSpec] -> IO ()
 printMenuCustomCommands ihcSpecs = do
   printStrings $ (T.unpack . C.cmdName) <$> ihcSpecs

--- a/src/Handler/Git.hs
+++ b/src/Handler/Git.hs
@@ -28,8 +28,8 @@ gitHandler' grt@(GitRepoTrackable dir locSpec) = do
     else
          if H.force locSpec
             then do
-                processGitNonInteractiveForce grt
-            else processGitNonInteractive grt
+                lift $ processGitNonInteractiveForce grt
+            else lift $ processGitNonInteractive grt
   else
     errorNotGitRepo grt
 
@@ -238,13 +238,13 @@ gitPrintHandler (NHGit (GitRepoTrackable dir' _locSpec) nhg) = do
           NHNotGitRepo -> dir <> ": is not a git repo"
   liftIO $ putStrLn $ T.unpack $ format
 
-processGitNonInteractive :: GitRepoTrackable -> R.Reddup  ()
+processGitNonInteractive :: GitRepoTrackable -> Tu.Shell ()
 processGitNonInteractive grTrack = do
-  lift $ checkGitProblems grTrack >>= gitPrintHandler
+  checkGitProblems grTrack >>= gitPrintHandler
 
-processGitNonInteractiveForce :: GitRepoTrackable -> R.Reddup ()
+processGitNonInteractiveForce :: GitRepoTrackable -> Tu.Shell ()
 processGitNonInteractiveForce grTrack =
-    lift . forever $
+    forever $
         checkGitProblems grTrack >>= tryFixGitProblem
 
 tryFixGitProblem :: NHGit -> Tu.Shell ()

--- a/src/Handler/Git.hs
+++ b/src/Handler/Git.hs
@@ -248,7 +248,7 @@ processGitNonInteractiveForce grTrack =
         checkGitProblems grTrack >>= tryFixGitProblem
 
 tryFixGitProblem :: NHGit -> Tu.Shell ()
-tryFixGitProblem nh@(NHGit (GitRepoTrackable _dir _locSpec) nhg) = do
+tryFixGitProblem nh@(NHGit _ nhg) = do
     case nhg of
         NHStatus (GP.Added _) ->
             addAndWipCommit
@@ -264,11 +264,9 @@ tryFixGitProblem nh@(NHGit (GitRepoTrackable _dir _locSpec) nhg) = do
             addAndWipCommit
         NHStatus (GP.Deleted _) ->
             addAndWipCommit
-        NHUnpushedBranch branch -> do
+        NHUnpushedBranch branch@(GP.GitBranch branchName) -> do
             targetAndMerge <- (,) <$> readPushTarget branch <*> readMerge branch
-            let (GP.GitBranch branchName) = branch
             liftIO $ gitPushCmd branchName (go targetAndMerge) mempty
-            pure ()
         _ -> do
             gitPrintHandler nh
             Tu.mzero

--- a/src/Trackable.hs
+++ b/src/Trackable.hs
@@ -4,7 +4,6 @@ module Trackable where
 
 import Prelude hiding (FilePath, concat)
 import qualified Turtle as Tu
--- import qualified System.IO as SIO
 import qualified ShellUtil
 import qualified Config as C
 import qualified Handler as H
@@ -41,9 +40,9 @@ locationSpecToTrackable ls = do
   let expand location =
         (Tu.fromText . Tu.lineToText) <$> (ShellUtil.expandGlob location)
   case ls of
-    C.GitLoc location -> do
+    C.GitLoc (C.GitLocation location) -> do
       path' <- (expand location)
       return $ GitRepo $ GitRepoTrackable path' ls
-    C.InboxLoc location _foo -> do
+    C.InboxLoc (C.InboxLocation location _) -> do
       path' <- (expand location)
       return $ InboxDir $ InboxDirTrackable path' ls

--- a/src/Trackable.hs
+++ b/src/Trackable.hs
@@ -40,7 +40,7 @@ locationSpecToTrackable ls = do
   let expand location =
         (Tu.fromText . Tu.lineToText) <$> (ShellUtil.expandGlob location)
   case ls of
-    C.GitLoc (C.GitLocation location) -> do
+    C.GitLoc (C.GitLocation location _) -> do
       path' <- (expand location)
       return $ GitRepo $ GitRepoTrackable path' ls
     C.InboxLoc (C.InboxLocation location _) -> do


### PR DESCRIPTION
What this does:
- adds an optional `force` flag for git locations
- when the flag is missing or false, there is no change from current behavior
- when the flag is true, we add a WIP commit and push changes to remote

NOTE: the `forever` there will stop when it reaches `mzero` so it should never get stuck in an infinite loop.

Changes, in chronological order of commits:
- `LocationSpec`'s `ignoredFiles` type was previously `Maybe [Text]` which wasn't necessary; changed it to `[Text]`
- Using `ignoredFiles` on a `GitLoc` would result in a runtime error, so I added an extra indirection/type to make things safer
- The *BIG* one, this adds all of the functionality; this is probably what you want to review
- The following two commits are both very minor refactors
- The last commit adds documentation to the README